### PR TITLE
GitHub リポジトリへのリンクをフッタに追加

### DIFF
--- a/classes/agent/config.html
+++ b/classes/agent/config.html
@@ -194,6 +194,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/agent/config.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/agent/config.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/agent/usage.html
+++ b/classes/agent/usage.html
@@ -532,6 +532,7 @@ else
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/agent/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/agent/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/arr.html
+++ b/classes/arr.html
@@ -1364,6 +1364,7 @@ $bool = in_arrayi('Thi', array('something','tHis'));
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/arr.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/arr.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/asset/advanced.html
+++ b/classes/asset/advanced.html
@@ -187,6 +187,7 @@ Asset::instance('custom')->css(array('header.css', 'footer.css'), array(), 'layo
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/asset/advanced.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/asset/advanced.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/asset/config.html
+++ b/classes/asset/config.html
@@ -222,6 +222,7 @@ echo Asset::img('icons/myicon.png');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/asset/config.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/asset/config.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/asset/usage.html
+++ b/classes/asset/usage.html
@@ -578,6 +578,7 @@ echo Asset::render();</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/asset/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/asset/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/autoloader.html
+++ b/classes/autoloader.html
@@ -479,6 +479,7 @@ Autoloader::alias_to_namespace('Mynamspace\\Myclass', 'Other\\Namespace\\');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/autoloader.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/autoloader.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/cache/advanced.html
+++ b/classes/cache/advanced.html
@@ -61,6 +61,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/cache/advanced.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/cache/advanced.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/cache/config.html
+++ b/classes/cache/config.html
@@ -186,6 +186,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/cache/config.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/cache/config.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/cache/usage.html
+++ b/classes/cache/usage.html
@@ -351,6 +351,7 @@ Cache::call('article_something', array('Model_Article', 'find'), array("all", ar
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/cache/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/cache/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/cli.html
+++ b/classes/cli.html
@@ -396,6 +396,7 @@ Cli::wait(5, true);</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/cli.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/cli.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/config.html
+++ b/classes/config.html
@@ -373,6 +373,7 @@ Config::save('foo::custom', 'bar');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/config.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/config.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/cookie.html
+++ b/classes/cookie.html
@@ -286,6 +286,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/cookie.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/cookie.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/crypt.html
+++ b/classes/crypt.html
@@ -198,6 +198,7 @@ $value = Crypt::decode($value, 'R@nd0mK~Y');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/crypt.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/crypt.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/db.html
+++ b/classes/database/db.html
@@ -1167,6 +1167,7 @@ catch (Exception $e)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/db.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/db.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/dbutil.html
+++ b/classes/database/dbutil.html
@@ -1323,6 +1323,7 @@ else
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/dbutil.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/dbutil.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/introduction.html
+++ b/classes/database/introduction.html
@@ -171,6 +171,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/introduction.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/introduction.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/qb.html
+++ b/classes/database/qb.html
@@ -79,6 +79,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/qb.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/qb.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/qb_delete.html
+++ b/classes/database/qb_delete.html
@@ -215,6 +215,7 @@ $sql = $query->compile($connection);
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/qb_delete.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/qb_delete.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/qb_insert.html
+++ b/classes/database/qb_insert.html
@@ -382,6 +382,7 @@ $query->table('admins')->set(array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/qb_insert.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/qb_insert.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/qb_select.html
+++ b/classes/database/qb_select.html
@@ -960,6 +960,7 @@ $query->select('email')->from('admins')->where('role', 'superadmin');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/qb_select.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/qb_select.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/qb_update.html
+++ b/classes/database/qb_update.html
@@ -438,6 +438,7 @@ $query->value('users.profile_type', \DB::expr('`profiles`.`type`'));
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/qb_update.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/qb_update.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/qb_where.html
+++ b/classes/database/qb_where.html
@@ -502,6 +502,7 @@ $query->limit(10);
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/qb_where.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/qb_where.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/database/usage.html
+++ b/classes/database/usage.html
@@ -500,6 +500,7 @@ Cache::delete_all("db");</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/database/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/database/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/date.html
+++ b/classes/date.html
@@ -630,6 +630,7 @@ echo Date::forge(1294176140)->get_timezone_abbr(true); // returns "CET" too</cod
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/date.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/date.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/debug.html
+++ b/classes/debug.html
@@ -327,6 +327,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/debug.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/debug.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/event.html
+++ b/classes/event.html
@@ -189,6 +189,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/event.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/event.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/fieldset.html
+++ b/classes/fieldset.html
@@ -912,6 +912,7 @@ $fieldset->form()->set_attribute('id', 'edit_article_form');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/fieldset.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/fieldset.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/file/advanced.html
+++ b/classes/file/advanced.html
@@ -150,6 +150,7 @@ catch(\FileAccessException $e)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/file/advanced.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/file/advanced.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/file/handlers.html
+++ b/classes/file/handlers.html
@@ -930,6 +930,7 @@ class File_Handler_XML extends \File_Handler_File
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/file/handlers.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/file/handlers.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/file/intro.html
+++ b/classes/file/intro.html
@@ -144,6 +144,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/file/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/file/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/file/usage.html
+++ b/classes/file/usage.html
@@ -1330,6 +1330,7 @@ File::close_file($resource);</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/file/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/file/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/finder.html
+++ b/classes/finder.html
@@ -450,6 +450,7 @@ $viewfile = Finder::instance()->locate('views', 'welcome/index');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/finder.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/finder.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/form.html
+++ b/classes/form.html
@@ -665,6 +665,7 @@ echo Form::fieldset_close();</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/form.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/form.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/format.html
+++ b/classes/format.html
@@ -360,6 +360,7 @@ Array
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/format.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/format.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/ftp.html
+++ b/classes/ftp.html
@@ -451,6 +451,7 @@ $ftp->close();</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/ftp.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/ftp.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/fuel.html
+++ b/classes/fuel.html
@@ -317,6 +317,7 @@ if (Fuel::load('myfile.php'))
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/fuel.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/fuel.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/html.html
+++ b/classes/html.html
@@ -718,6 +718,7 @@ echo Html::ol($items, $attr);</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/html.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/html.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/image.html
+++ b/classes/image.html
@@ -1044,6 +1044,7 @@ Image::load('filename.gif')
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/image.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/image.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/inflector.html
+++ b/classes/inflector.html
@@ -724,6 +724,7 @@ echo Inflector::is_countable('apple'); // returns true</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/inflector.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/inflector.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/input.html
+++ b/classes/input.html
@@ -801,6 +801,7 @@ fe80::/10      // link local unicast (rfc4291)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/input.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/input.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/lang.html
+++ b/classes/lang.html
@@ -384,6 +384,7 @@ $this->output = __('test.something');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/lang.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/lang.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/log.html
+++ b/classes/log.html
@@ -407,6 +407,7 @@ Log::write('Link', 'More info on http://fuelphp.com/')</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/log.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/log.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/markdown.html
+++ b/classes/markdown.html
@@ -112,6 +112,7 @@ plain text format, then convert it to structurally valid HTML.&lt;/p&gt;
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/markdown.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/markdown.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/migrate.html
+++ b/classes/migrate.html
@@ -203,6 +203,7 @@ Migrate::version(10, 'mymodule', 'module');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/migrate.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/migrate.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/model_crud/introduction.html
+++ b/classes/model_crud/introduction.html
@@ -230,6 +230,7 @@ class Model_Users extends \Model_Crud
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/model_crud/introduction.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/model_crud/introduction.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/model_crud/methods.html
+++ b/classes/model_crud/methods.html
@@ -1342,6 +1342,7 @@ protected function prep_values($data)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/model_crud/methods.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/model_crud/methods.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/module.html
+++ b/classes/module.html
@@ -254,6 +254,7 @@ if (Module::exists('comments'))
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/module.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/module.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/mongo/introduction.html
+++ b/classes/mongo/introduction.html
@@ -138,6 +138,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/mongo/introduction.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/mongo/introduction.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/mongo/methods.html
+++ b/classes/mongo/methods.html
@@ -1873,6 +1873,7 @@ $indexes = $mongodb->list_indexes('my_collection');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/mongo/methods.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/mongo/methods.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/num.html
+++ b/classes/num.html
@@ -609,6 +609,7 @@ echo Num::mask_credit_card('1234123412341234', '0000 **** **** ****');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/num.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/num.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/package.html
+++ b/classes/package.html
@@ -204,6 +204,7 @@ array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/package.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/package.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/pagination.html
+++ b/classes/pagination.html
@@ -371,6 +371,7 @@ $this->render('welcome/index', $data);</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/pagination.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/pagination.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/profiler.html
+++ b/classes/profiler.html
@@ -188,6 +188,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/profiler.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/profiler.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/redis.html
+++ b/classes/redis.html
@@ -123,6 +123,7 @@ echo "&lt;/ul>";
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/redis.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/redis.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/request.html
+++ b/classes/request.html
@@ -534,6 +534,7 @@ $paths = Request::active()->get_paths();</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/request.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/request.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/response.html
+++ b/classes/response.html
@@ -214,6 +214,7 @@ Response::redirect('site/about');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/response.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/response.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/router.html
+++ b/classes/router.html
@@ -287,6 +287,7 @@ Router::delete('module/controller(:any)');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/router.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/router.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/security.html
+++ b/classes/security.html
@@ -518,6 +518,7 @@ $text = e($text);</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/security.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/security.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/session/advanced.html
+++ b/classes/session/advanced.html
@@ -394,6 +394,7 @@ $(function()
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/session/advanced.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/session/advanced.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/session/config.html
+++ b/classes/session/config.html
@@ -476,6 +476,7 @@ $ php oil r session:clear</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/session/config.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/session/config.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/session/usage.html
+++ b/classes/session/usage.html
@@ -679,6 +679,7 @@ $session_id = Session::key('session_id');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/session/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/session/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/str.html
+++ b/classes/str.html
@@ -387,6 +387,7 @@ echo $alt(); // outputs 'one'
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/str.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/str.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/theme/advanced.html
+++ b/classes/theme/advanced.html
@@ -155,6 +155,7 @@ $theme->active(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/theme/advanced.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/theme/advanced.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/theme/introduction.html
+++ b/classes/theme/introduction.html
@@ -300,6 +300,7 @@ return array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/theme/introduction.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/theme/introduction.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/theme/methods.html
+++ b/classes/theme/methods.html
@@ -1184,6 +1184,7 @@ $var = $theme->set_info('color', 'blue', 'fallback');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/theme/methods.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/theme/methods.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/upload/config.html
+++ b/classes/upload/config.html
@@ -259,6 +259,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/upload/config.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/upload/config.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/upload/usage.html
+++ b/classes/upload/usage.html
@@ -697,6 +697,7 @@ foreach ( Upload::get_errors() as $key => $file )
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/upload/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/upload/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/uri.html
+++ b/classes/uri.html
@@ -368,6 +368,7 @@ echo Uri::string(); // controller/method が返ります。</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/uri.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/uri.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/validation/errors.html
+++ b/classes/validation/errors.html
@@ -235,6 +235,7 @@ $field->add_rule(array('odd' => function($val) { return (bool) ($val % 2); }));
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/validation/errors.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/validation/errors.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/validation/methods.html
+++ b/classes/validation/methods.html
@@ -560,6 +560,7 @@ $val->get_message('required', null);
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/validation/methods.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/validation/methods.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/validation/validation.html
+++ b/classes/validation/validation.html
@@ -451,6 +451,7 @@ $val->add_model('Model_User');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/validation/validation.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/validation/validation.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/classes/view.html
+++ b/classes/view.html
@@ -650,6 +650,7 @@ $html = View::forge()->set_filename('path/to/view')->render();</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/classes/view.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/classes/view.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/contribute.html
+++ b/contribute.html
@@ -106,6 +106,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/contribute.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/contribute.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/credits.html
+++ b/credits.html
@@ -72,6 +72,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/credits.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/credits.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/classes.html
+++ b/general/classes.html
@@ -116,6 +116,7 @@ class Messages {}
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/classes.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/classes.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/coding_standards.html
+++ b/general/coding_standards.html
@@ -338,6 +338,7 @@ $var++; // 加算演算子の前にスペースをいれない
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/coding_standards.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/coding_standards.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/configuration.html
+++ b/general/configuration.html
@@ -405,6 +405,7 @@ E_STRICT
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/configuration.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/configuration.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/constants.html
+++ b/general/constants.html
@@ -105,6 +105,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/constants.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/constants.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/controllers/base.html
+++ b/general/controllers/base.html
@@ -245,6 +245,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/controllers/base.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/controllers/base.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/controllers/hybrid.html
+++ b/general/controllers/hybrid.html
@@ -87,6 +87,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/controllers/hybrid.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/controllers/hybrid.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/controllers/rest.html
+++ b/general/controllers/rest.html
@@ -180,6 +180,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/controllers/rest.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/controllers/rest.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/controllers/template.html
+++ b/general/controllers/template.html
@@ -188,6 +188,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/controllers/template.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/controllers/template.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/environments.html
+++ b/general/environments.html
@@ -128,6 +128,7 @@ Fuel::$env = (isset($_SERVER['FUEL_ENV']) ? $_SERVER['FUEL_ENV'] : Fuel::DEVELOP
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/environments.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/environments.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/error.html
+++ b/general/error.html
@@ -185,6 +185,7 @@ public function action_my404()
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/error.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/error.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/extending_core.html
+++ b/general/extending_core.html
@@ -136,6 +136,7 @@ Autoloader::add_classes(array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/extending_core.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/extending_core.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/hmvc.html
+++ b/general/hmvc.html
@@ -124,6 +124,7 @@ catch (HttpNotFoundException $e)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/hmvc.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/hmvc.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/migrations.html
+++ b/general/migrations.html
@@ -114,6 +114,7 @@ $ php oil refine migrate --version=10</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/migrations.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/migrations.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/models.html
+++ b/general/models.html
@@ -156,6 +156,7 @@ $entry = Model_Article::find('all', array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/models.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/models.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/modules.html
+++ b/general/modules.html
@@ -207,6 +207,7 @@ Module::load('mymodule');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/modules.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/modules.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/mvc.html
+++ b/general/mvc.html
@@ -95,6 +95,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/mvc.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/mvc.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/packages.html
+++ b/general/packages.html
@@ -129,6 +129,7 @@ $instance = new Mynamespace\Myclass;
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/packages.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/packages.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/profiling.html
+++ b/general/profiling.html
@@ -109,6 +109,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/profiling.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/profiling.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/routing.html
+++ b/general/routing.html
@@ -193,6 +193,7 @@ echo Html::anchor(Router::get('admin_overview'), 'Overview');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/routing.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/routing.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/security.html
+++ b/general/security.html
@@ -213,6 +213,7 @@ if ($_POST)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/security.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/security.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/tasks.html
+++ b/general/tasks.html
@@ -88,6 +88,7 @@ class Example
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/tasks.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/tasks.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/unit_testing.html
+++ b/general/unit_testing.html
@@ -200,6 +200,7 @@ class Test_Model_Login extends TestCase
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/unit_testing.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/unit_testing.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/viewmodels.html
+++ b/general/viewmodels.html
@@ -170,6 +170,7 @@ ViewModel::forge('Index', 'other_method');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/viewmodels.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/viewmodels.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/general/views.html
+++ b/general/views.html
@@ -266,6 +266,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/general/views.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/general/views.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@ $ oil create blog</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/index.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/index.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/installation/download.html
+++ b/installation/download.html
@@ -101,6 +101,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/installation/download.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/installation/download.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/installation/instructions.html
+++ b/installation/instructions.html
@@ -152,6 +152,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/installation/instructions.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/installation/instructions.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/installation/troubleshooting.html
+++ b/installation/troubleshooting.html
@@ -247,6 +247,7 @@ $ sudo ln -s /Applications/MAMP/tmp/mysql/mysql.sock /var/mysql/mysql.sock</code
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/installation/troubleshooting.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/installation/troubleshooting.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/license.html
+++ b/license.html
@@ -79,6 +79,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/license.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/license.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/drivers.html
+++ b/packages/auth/drivers.html
@@ -146,6 +146,7 @@ public function get_user_id()
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/drivers.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/drivers.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/intro.html
+++ b/packages/auth/intro.html
@@ -151,6 +151,7 @@ return array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/simpleauth/acl.html
+++ b/packages/auth/simpleauth/acl.html
@@ -154,6 +154,7 @@ if (Auth::has_access(array('blog' => array('read'), 'comments' => array('read'))
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/simpleauth/acl.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/simpleauth/acl.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/simpleauth/groups.html
+++ b/packages/auth/simpleauth/groups.html
@@ -183,6 +183,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/simpleauth/groups.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/simpleauth/groups.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/simpleauth/intro.html
+++ b/packages/auth/simpleauth/intro.html
@@ -232,6 +232,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/simpleauth/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/simpleauth/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/simpleauth/login.html
+++ b/packages/auth/simpleauth/login.html
@@ -601,6 +601,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/simpleauth/login.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/simpleauth/login.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/types/acl.html
+++ b/packages/auth/types/acl.html
@@ -255,6 +255,7 @@ if ( ! Auth::instance('simpleacl')->has_access('comments.create'), array('simple
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/types/acl.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/types/acl.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/types/group.html
+++ b/packages/auth/types/group.html
@@ -378,6 +378,7 @@ Auth::instance('simplegroup')->get_name('admin');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/types/group.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/types/group.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/types/login.html
+++ b/packages/auth/types/login.html
@@ -544,6 +544,7 @@ $password = Auth::instance()->hash_password($password);
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/types/login.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/types/login.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/auth/usage.html
+++ b/packages/auth/usage.html
@@ -394,6 +394,7 @@ Auth::unregister_driver_type('role');
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/auth/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/auth/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/email/introduction.html
+++ b/packages/email/introduction.html
@@ -331,6 +331,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/email/introduction.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/email/introduction.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/email/methods.html
+++ b/packages/email/methods.html
@@ -1215,6 +1215,7 @@ catch(\EmailValidationFailedException $e)
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/email/methods.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/email/methods.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/email/usage.html
+++ b/packages/email/usage.html
@@ -170,6 +170,7 @@ $email->string_attach($contents, $filename);
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/email/usage.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/email/usage.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/oil/console.html
+++ b/packages/oil/console.html
@@ -75,6 +75,7 @@ Bobby the Gibbon</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/oil/console.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/oil/console.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/oil/generate.html
+++ b/packages/oil/generate.html
@@ -529,6 +529,7 @@ Migrated to latest version: 3.
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/oil/generate.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/oil/generate.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/oil/intro.html
+++ b/packages/oil/intro.html
@@ -114,6 +114,7 @@ Documentation:
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/oil/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/oil/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/oil/package.html
+++ b/packages/oil/package.html
@@ -107,6 +107,7 @@ Uninstalling package "test-package"</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/oil/package.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/oil/package.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/oil/refine.html
+++ b/packages/oil/refine.html
@@ -93,6 +93,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/oil/refine.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/oil/refine.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/creating_models.html
+++ b/packages/orm/creating_models.html
@@ -171,6 +171,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/creating_models.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/creating_models.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/crud.html
+++ b/packages/orm/crud.html
@@ -212,6 +212,7 @@ Model_Article::find('all', array('where' => array(array('category_id', '=', 5), 
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/crud.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/crud.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/intro.html
+++ b/packages/orm/intro.html
@@ -102,6 +102,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/observers/creating.html
+++ b/packages/orm/observers/creating.html
@@ -118,6 +118,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/observers/creating.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/observers/creating.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/observers/included.html
+++ b/packages/orm/observers/included.html
@@ -340,6 +340,7 @@ protected static $_observers = array('Orm\\Observer_Slug' => array('before_inser
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/observers/included.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/observers/included.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/observers/intro.html
+++ b/packages/orm/observers/intro.html
@@ -87,6 +87,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/observers/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/observers/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/relations/belongs_to.html
+++ b/packages/orm/relations/belongs_to.html
@@ -103,6 +103,7 @@ protected static $_belongs_to = array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/relations/belongs_to.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/relations/belongs_to.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/relations/has_many.html
+++ b/packages/orm/relations/has_many.html
@@ -105,6 +105,7 @@ protected static $_has_many = array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/relations/has_many.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/relations/has_many.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/relations/has_one.html
+++ b/packages/orm/relations/has_one.html
@@ -105,6 +105,7 @@ protected static $_has_one = array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/relations/has_one.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/relations/has_one.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/relations/intro.html
+++ b/packages/orm/relations/intro.html
@@ -304,6 +304,7 @@ $post = Model_Post::query()
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/relations/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/relations/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/orm/relations/many_many.html
+++ b/packages/orm/relations/many_many.html
@@ -157,6 +157,7 @@ protected static $_many_many = array(
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/orm/relations/many_many.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/orm/relations/many_many.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/packages/parser/intro.html
+++ b/packages/parser/intro.html
@@ -122,6 +122,7 @@ View_Smarty::parser()->clearCache('example.smarty');</code></pre>
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/packages/parser/intro.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/packages/parser/intro.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/requirements.html
+++ b/requirements.html
@@ -103,6 +103,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/requirements.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/requirements.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,6 +57,7 @@
 		<footer>
 			<p>
 				&copy; FuelPHP Development Team 2010-2012 - <a href="http://fuelphp.com">FuelPHP</a> is released under the MIT license.
+[ <a href="https://github.com/fuel/docs/commits/1.2/develop/templates/index.html">原文コミット履歴</a> | <a href="https://github.com/NEKOGET/FuelPHP_docs_jp/commits/1.2/develop_japanese/templates/index.html">翻訳コミット履歴</a> ]
 			</p>
 		</footer>
 	</div>


### PR DESCRIPTION
翻訳状況や翻訳への参加がわかりやすいように、コミット履歴へのリンクを追加してみました。
