### PR TITLE
typoの修正

### DIFF
--- a/general/controllers/base.html
+++ b/general/controllers/base.html
@@ -181,7 +181,7 @@ class Example extends Controller
 				<h4 id="before">before()</h4>
 				<p>
 					このメソッドは、コントローラで URL で指定されたメソッドが呼び出される<strong>前</strong> に実行されます。
-					たとえメソッドが存在しない場合出あってもです。
+					たとえメソッドが存在しない場合であってもです。
 				</p>
 			</article>
 


### PR DESCRIPTION
1.2/develop_japanese で修正したコントローラーページ内、before()に関する項目でのtypoの修正をコチラにも反映しました。
