### PR TITLE
1.3/develop japanese

### DIFF
--- a/classes/debug.html
+++ b/classes/debug.html
@@ -11,7 +11,7 @@
 		var class_prefix = "Debug::";
 	</script>
 	<script src="./../assets/js/combined.js"></script>
-	<title>Debug - Classes - FuelPHP Documentation</title>
+	<title>Debug - クラス - FuelPHP ドキュメント</title>
 </head>
 <body>
 	<div id="container">
@@ -48,13 +48,15 @@
 			<h2>Debug クラス</h2>
 
 			<p>
-				The Debug class is a simple utility for debugging variables, objects, arrays, etc by outputting information to the display. This is not
-				meant as a one-stop-shop to all of your debugging needs, but as a simple way to throw out information quickly to check things as you go.
+			  Debug クラスは値やオブジェクト、配列などの情報を表示するためのシンプルなユーティリティクラスです。<br />
+			  デバッグに関する機能が全部入りというわけではありませんが、パッと情報を確認したい時には簡単な方法です。
 			</p>
 
 			<article>
 				<h4 class="method" id="method_dump">dump(*$args)</h4>
-				<p>The <strong>dump</strong> method outputs multiple mixed values to the browser in a formatted structured way and includes backtrace information so you know where it is coming from.</p>
+				<p>
+				  <strong>dump</strong>は値やオブジェクト、配列などを整形してブラウザに出力します。<br /> また、バックトレースの情報も含まれるので、そのオブジェクトがどこから来たのかを把握することができます。
+				</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -63,7 +65,7 @@
 					</tr>
 					<tr>
 						<th>パラメータ</th>
-						<td>Unlimited mixed arguments</td>
+						<td>引数の数や種類に制限はありません。 </td>
 					</tr>
 					<tr>
 						<th>返り値</th>
@@ -78,14 +80,15 @@
 					</tbody>
 				</table>
 				<p class="note">
-					By default nested structures will be displayed collapsed to minimize the impact of the output on the page layout. You can
-					alter this behaviour and have it expand by default by setting <strong>Debug::$js_toggle_open</strong> to <strong>true<strong>.
-				</p>
+					デフォルトではネストしたオブジェクトや配列は折り畳まれて表示されます。<br />	最初からすべて開いた状態で表示させたい場合は、setting.phpの<strong>Debug::$js_toggle_open</strong>を<strong>true</strong>に変更してください。
+					</p>
 			</article>
 
 			<article>
 				<h4 class="method" id="method_backtrace">backtrace()</h4>
-				<p>The <strong>backtrace</strong> method shows the file and line the method is called from and a list of all previous.</p>
+				<p>
+				  <strong>backtrace</strong>はこの関数が呼び出されるまでに通ったすべての関数のファイル名や行の一覧を表示します。
+				</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -112,7 +115,7 @@
 
 			<article>
 				<h4 class="method" id="method_classes">classes()</h4>
-				<p>Output a list of all classes currently defined in the PHP runtime.</p>
+				<p>現在、PHPランタイム上で定義されているクラスの一覧を表示します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -139,7 +142,8 @@
 
 			<article>
 				<h4 class="method" id="method_interfaces">interfaces()</h4>
-				<p>Output a list of all <a href="http://uk.php.net/interfaces" target="_blank">interface classes</a> currently defined in the PHP runtime.</p>
+				<p>現在、PHPランタイム上で定義されている<a href="http://jp.php.net/interfaces" target="_blank">インターフェースクラス</a>の一覧を出力します。</p>
+        
 				<table class="method">
 					<tbody>
 					<tr>
@@ -166,7 +170,9 @@
 
 			<article>
 				<h4 class="method" id="method_includes">includes()</h4>
-				<p>Output a list of all included files currently loaded in the PHP runtime.</p>
+				<p>
+				  現在、PHPランタイム上で読み込まれているファイルの一覧を出力します。
+				</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -193,7 +199,7 @@
 
 			<article>
 				<h4 class="method" id="method_functions">functions()</h4>
-				<p>Output a list of all functions currently defined in the PHP runtime.</p>
+				<p>現在、PHPランタイム上で定義されている関数の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -220,7 +226,7 @@
 
 			<article>
 				<h4 class="method" id="method_constants">constants()</h4>
-				<p>Output a list of all constants currently defined in the PHP runtime.</p>
+				<p>現在、PHPランタイム上で定義されている定数の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -247,7 +253,7 @@
 
 			<article>
 				<h4 class="method" id="method_extensions">extensions()</h4>
-				<p>Output a list of all extensions loaded by PHP.</p>
+				<p>現在、ロードされているPHPの拡張の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
@@ -274,8 +280,8 @@
 
 			<article>
 				<h4 class="method" id="method_headers">headers()</h4>
-				<p>Output a list of all HTTP headers the server was requested with.</p>
-				<table class="method">
+				<p>現在のリクエストのHTTPヘッダの一覧を出力します。</p>
+        <table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
@@ -301,7 +307,7 @@
 
 			<article>
 				<h4 class="method" id="method_phpini">phpini()</h4>
-				<p>Prints a list of the configuration settings read from <i>php.ini</i></p>
+				<p><i>php.ini</i>から読み込まれた設定の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>

--- a/classes/debug.html
+++ b/classes/debug.html
@@ -49,7 +49,8 @@
 
 			<p>
 			  Debug クラスは値やオブジェクト、配列などの情報を表示するためのシンプルなユーティリティクラスです。<br />
-			  デバッグに関する機能が全部入りというわけではありませんが、パッと情報を確認したい時には簡単な方法です。
+			  デバッグに関する機能が全部入りというわけではありませんが、パッと情報を確認したい時には簡単な方法です。<br />
+			  Debug クラスのいくつかの機能は、<a href="./profiler.html" target="_blank">Profiler</a>からも確認することができます。
 			</p>
 
 			<article>
@@ -80,7 +81,7 @@
 					</tbody>
 				</table>
 				<p class="note">
-					デフォルトではネストしたオブジェクトや配列は折り畳まれて表示されます。<br />	最初からすべて開いた状態で表示させたい場合は、setting.phpの<strong>Debug::$js_toggle_open</strong>を<strong>true</strong>に変更してください。
+					デフォルトではネストしたオブジェクトや配列は折り畳まれて表示されます。<br />	最初からすべて開いた状態で表示させたい場合は、<strong>Debug::$js_toggle_open</strong>に<strong>true</strong>を設定してください。
 					</p>
 			</article>
 

--- a/classes/debug.html
+++ b/classes/debug.html
@@ -88,7 +88,7 @@
 			<article>
 				<h4 class="method" id="method_backtrace">backtrace()</h4>
 				<p>
-				  <strong>backtrace</strong>はこの関数が呼び出されるまでに通ったすべての関数のファイル名や行の一覧を表示します。
+				  <strong>backtrace</strong>はこのメソッドが呼び出されるまでに通ったすべてのメソッドのファイル名や行の一覧を表示します。
 				</p>
 				<table class="method">
 					<tbody>
@@ -200,7 +200,7 @@
 
 			<article>
 				<h4 class="method" id="method_functions">functions()</h4>
-				<p>現在、PHPランタイム上で定義されている関数の一覧を出力します。</p>
+				<p>現在、PHPランタイム上で定義されているメソッドの一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>

--- a/classes/profiler.html
+++ b/classes/profiler.html
@@ -46,14 +46,12 @@
 		<div id="main">
 
 			<h2>Profiler クラス</h2>
-
-			<p>The profiler class allows you to add your own profiling information to the profiler.</p>
+			<p><strong>Profiler クラス</strong>を使うと、独自のプロファイリング情報をプロファイラに送ることができます。</p>
 
 			<article>
 				<h4 class="method" id="method_mark">mark($label)</h4>
 				<p>
-					The <strong>mark</strong> method will add a speed marker to the profiler.
-					This marker will show in the "Load Time" section of the profiler.
+					<strong>mark</strong>はスピードマーカーをプロファイラに追加します。<br />追加されたマーカーはプロファイラの"Load Time"セクションで確認することができます。
 				</p>
 				<table class="method">
 					<tbody>
@@ -73,7 +71,9 @@
 								<tr>
 									<th><kbd>$label</kbd></th>
 									<td><i>必須</i></td>
-									<td>A text label to describe the marker to be set.</td>
+									<td>
+									 スピードマーカーの説明
+									</td>
 								</tr>
 							</table>
 						</td>
@@ -85,7 +85,7 @@
 					<tr>
 						<th>例</th>
 						<td>
-							<pre class="php"><code>Profiler::mark('start of this piece of code');</code></pre>
+							<pre class="php"><code>Profiler::mark('これはメソッドの開始地点です');</code></pre>
 						</td>
 					</tr>
 					</tbody>
@@ -95,9 +95,8 @@
 			<article>
 				<h4 class="method" id="method_mark_memory">mark_memory($var, $name)</h4>
 				<p>
-					The <strong>mark_memory</strong> method will add a memory marker to the profiler.
-					If you pass a variable, the memory usage of that variable will be logged.
-					If not, the memory usage at the time of marking will be logged.
+					<strong>mark_memory</strong>はメモリマーカーをプロファイラに追加します。<br/>
+					変数を渡した場合、その変数のメモリ使用量が記録されます。そうでない場合は、その時点でのメモリ使用量が記録されます。
 				</p>
 				<table class="method">
 					<tbody>
@@ -117,12 +116,14 @@
 								<tr>
 									<th><kbd>$var</kbd></th>
 									<td><kbd>false</kbd></td>
-									<td>The variable whose size has to be logged. If false or not specified, PHP memory usage will be logged.</td>
+									<td>サイズを取得したい変数。もし、falseを渡すか、何も渡さない場合は全体のメモリ使用量が記録されます。</td>
 								</tr>
 								<tr>
 									<th><kbd>$name</kbd></th>
 									<td><kbd>'Memory&nbsp;Usage'</kbd></td>
-									<td>A text label to describe the marker to be set.</td>
+									<td>
+									 マーカーの説明
+									</td>
 								</tr>
 							</table>
 						</td>
@@ -134,7 +135,7 @@
 					<tr>
 						<th>例</th>
 						<td>
-							<pre class="php"><code>Profiler::mark_memory($this, 'Controller_Welcome object');</code></pre>
+							<pre class="php"><code>Profiler::mark_memory($this, 'Controller_Welcome オブジェクトです');</code></pre>
 						</td>
 					</tr>
 					</tbody>
@@ -142,9 +143,10 @@
 			</article>
 
 			<article>
-				<h4 class="method" id="method_log">log($text)</h4>
+				<h4 class="method" id="method_console">console($text)</h4>
 				<p>
-					The <strong>log</strong> method will add a log entry to the profiler.
+				  <strong>console</strong>はログをプロファイラに追加します。<br />
+				  "Console"セクションで確認することができます。
 				</p>
 				<table class="method">
 					<tbody>
@@ -164,7 +166,9 @@
 								<tr>
 									<th><kbd>$text</kbd></th>
 									<td><i>必須</i></td>
-									<td>A text to describe the log entry to be set.</td>
+									<td>
+									 プロファイラへ追加するログ
+									</td>
 								</tr>
 							</table>
 						</td>
@@ -176,7 +180,7 @@
 					<tr>
 						<th>例</th>
 						<td>
-							<pre class="php"><code>Profiler::log('start of this piece of code');</code></pre>
+							<pre class="php"><code>Profiler::console('プロファイラに表示させる文章');</code></pre>
 						</td>
 					</tr>
 					</tbody>


### PR DESCRIPTION
かなり意訳してしまったところもありますが、デバッグクラスとプロファイラクラスを翻訳しました。

`Profiler::log`が`Profiler::console`に置き換えられていたので修正しました。
(が、`Profiler::console`も不具合で動いていないので、本家に修正を送ろうと思います。
今はドキュメントの通りに動作しません)

よろしくお願いします。
