### PR TITLE
classes/debug.html の未翻訳箇所の翻訳と校正。

### DIFF
--- a/classes/debug.html
+++ b/classes/debug.html
@@ -54,12 +54,15 @@
 
 			<article>
 				<h4 class="method" id="method_dump">dump(*$args)</h4>
-				<p><strong>dump</strong>は値やオブジェクト、配列などを整形してブラウザに出力します。<br /> また、バックトレースの情報も含まれるので、そのオブジェクトがどこから来たのかを把握することができます。</p>
+				<p>
+					<strong>dump</strong> は値やオブジェクト、配列などを整形してブラウザに出力します。
+					また、バックトレースの情報も含まれるので、そのオブジェクトがどこから来たのかを把握することができます。
+				</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -78,19 +81,19 @@
 					</tbody>
 				</table>
 				<p class="note">
-					By default nested structures will be displayed collapsed to minimize the impact of the output on the page layout. You can
-					alter this behaviour and have it expand by default by setting <strong>Debug::$js_toggle_open</strong> to <strong>true<strong>.
+					デフォルトでは入れ子になった構造は、ページレイアウトへの影響を最小限に抑えるため、折りたたまれた状態で表示されます。
+					この動作は <strong>Debug::$js_toggle_open</strong> の設定値を <strong>true</strong> にすることで変更することができます
 				</p>
 			</article>
 
 			<article>
 				<h4 class="method" id="method_backtrace">backtrace()</h4>
-				<p><strong>backtrace</strong>はこのメソッドが呼び出されるまでに通ったすべてのメソッドのファイル名や行の一覧を表示します。</p>
+				<p><strong>backtrace</strong> はこのメソッドが呼び出されるまでに通ったすべてのメソッドのファイル名や行の一覧を表示します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -112,12 +115,12 @@
 
 			<article>
 				<h4 class="method" id="method_classes">classes()</h4>
-				<p>現在、PHPランタイム上で定義されているクラスの一覧を表示します。</p>
+				<p>現在、PHP ランタイム上で定義されているクラスの一覧を表示します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -144,7 +147,7 @@
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -166,12 +169,12 @@
 
 			<article>
 				<h4 class="method" id="method_includes">includes()</h4>
-				<p>現在、PHPランタイム上で読み込まれているファイルの一覧を出力します。</p>
+				<p>現在、PHP ランタイム上で読み込まれているファイルの一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -193,12 +196,12 @@
 
 			<article>
 				<h4 class="method" id="method_functions">functions()</h4>
-				<p>現在、PHPランタイム上で定義されているメソッドの一覧を出力します。</p>
+				<p>現在、PHP ランタイム上で定義されているメソッドの一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -220,12 +223,12 @@
 
 			<article>
 				<h4 class="method" id="method_constants">constants()</h4>
-				<p>現在、PHPランタイム上で定義されている定数の一覧を出力します。</p>
+				<p>現在、PHP ランタイム上で定義されている定数の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -247,12 +250,12 @@
 
 			<article>
 				<h4 class="method" id="method_extensions">extensions()</h4>
-				<p>現在、ロードされているPHPの拡張の一覧を出力します。</p>
+				<p>現在、ロードされている PHP の拡張の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -274,12 +277,12 @@
 
 			<article>
 				<h4 class="method" id="method_headers">headers()</h4>
-				<p>現在のリクエストのHTTPヘッダの一覧を出力します。</p>
-        <table class="method">
+				<p>現在のリクエストの HTTP ヘッダの一覧を出力します。</p>
+				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>
@@ -301,12 +304,12 @@
 
 			<article>
 				<h4 class="method" id="method_phpini">phpini()</h4>
-				<p><i>php.ini</i>から読み込まれた設定の一覧を出力します。</p>
+				<p><i>php.ini</i>　から読み込まれた設定の一覧を出力します。</p>
 				<table class="method">
 					<tbody>
 					<tr>
 						<th class="legend">Static</th>
-						<td>Yes</td>
+						<td>はい</td>
 					</tr>
 					<tr>
 						<th>パラメータ</th>


### PR DESCRIPTION
dump メソッドの注記の2段落目の翻訳はあやしいですが意味は通りやすくなったんじゃないかとおもいます。
