### PR TITLE
security.htmlを更新

### DIFF
--- a/classes/security.html
+++ b/classes/security.html
@@ -91,7 +91,7 @@
 						<tr>
 							<th>uri_filter</th>
 							<td>array</td>
-							<td><pre class="php"><code>array('htmlentities')</code></pre><br> （訳注：バージョン1.5.2では core/config/config.php で <pre class="php"><code>array()</code></pre> がセットされています。<br> app/config/config.php で上記の値をセットされることを推奨します。）</td>
+							<td><pre class="php"><code>array('htmlentities')</code></pre></td>
 							<td>
 								Array of callable items (PHP functions, object methods, static class methods) used to filter the URI. By default, it uses PHP's htmlentities internal function.
 							</td>
@@ -107,7 +107,7 @@
 						<tr>
 							<th>output_filter</th>
 							<td>array</td>
-							<td><pre class="php"><code>array('Security::htmlentities')</code></pre><br> （訳注：バージョン1.5.2では core/config/config.php で <pre class="php"><code>array()</code></pre> がセットされています。<br> app/config/config.php で上記の値をセットされることを推奨します。）</td>
+							<td><pre class="php"><code>array('Security::htmlentities')</code></pre></td>
 							<td>
 								Array of callable items (PHP functions, object methods, static class methods) used to filter variables send to a View or Viewmodel.
 								For security reasons, you are <strong>required</strong> to define an output filter.
@@ -116,7 +116,7 @@
 						<tr>
 							<th>htmlentities_flags</th>
 							<td>integer</td>
-							<td><pre class="php"><code>null</code></pre><br> （訳注：バージョン1.5.2では core/config/config.php で <pre class="php"><code>ENT_QUOTES</code></pre> がセットされています。）</td>
+							<td><pre class="php"><code>null</code></pre></td>
 							<td>
 								Flags to be used when encoding HTML entities. Defaults to ENT_QUOTES if nothing is defined.
 							</td>
@@ -124,7 +124,7 @@
 						<tr>
 							<th>htmlentities_double_encode</th>
 							<td>boolean</td>
-							<td><pre class="php"><code>null</code></pre><br> （訳注：バージョン1.5.2では core/config/config.php で <pre class="php"><code>false</code></pre> がセットされています。）</td>
+							<td><pre class="php"><code>null</code></pre></td>
 							<td>
 								Whether of not already encoded entities should be encoded again. Defaults to <strong>false</strong> if nothing is defined.
 							</td>
@@ -140,7 +140,7 @@
 						<tr>
 							<th>whitelisted_classes</th>
 							<td>array</td>
-							<td><pre class="php"><code>array('stdClass', 'Fuel\\Core\\View',<br /> 'Fuel\\Core\\ViewModel', 'Closure')</code></pre><br> （訳注：バージョン1.5.2では core/config/config.php で <pre class="php"><code>array()</code></pre> がセットされています。<br> app/config/config.php で上記の値をセットされることを推奨します。）</td>
+							<td><pre class="php"><code>array('stdClass', 'Fuel\\Core\\View',<br /> 'Fuel\\Core\\ViewModel', 'Closure')</code></pre></td>
 							<td>
 								When auto encoding of view variables is enabled, you can run into issues when passing objects to the view. Classes defined in this
 								array will be exempt from auto encoding.


### PR DESCRIPTION
v1.5〜1.5.2のセキュリティ問題についての訳注を削除
