### PR TITLE
CREDITS.md 更新

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,9 +1,12 @@
 # FuelPHP Documentation 日本語翻訳
 
+この FuelPHP Documentation 日本語翻訳は [MIT ライセンス](http://opensource.org/licenses/MIT) でリリースされています。
+
 ## Version 1.8
 
 * sharkpp <https://github.com/sharkpp>
 * Fumito Mizuno <https://github.com/ounziw>
+* Kenji Suzuki <https://github.com/kenjis>
 
 ## Version 1.7
 


### PR DESCRIPTION
日本語訳のライセンスも本家公式ドキュメント同様、MIT ライセンスであることを、明示しました。

@charlesvineyard
@chatii
@egmc
@h2ospace
@inouet
@kenjis
@koyhoge
@mazzo46
@miki-soichiro
@mp-php
@orcaaoshi
@ounziw
@raben
@seckie
@sharkpp
@shinagaki
@torut
@yoshiakist
