### PR TITLE
チュートリアルのリンク削除

### DIFF
--- a/assets/js/combined.js
+++ b/assets/js/combined.js
@@ -382,7 +382,6 @@ panes.main = {
 		"インストール方法":	"installation/instructions.html",
 		"ダウンロード":		"installation/download.html",
 		"アップグレード":	"installation/upgrade.html",
-		"チュートリアル":	"installation/tutorials.html",
 		"トラブルシューティング":		"installation/troubleshooting.html"
 	},
 	"概要": {


### PR DESCRIPTION
1.8のマージ漏れ。
チュートリアルのページが削除されたがリンクが残っています。
