### PR TITLE
oil のクイックインストールURLを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 			<p>もしあなたが今すぐに Fuel を試したいと思うなら、高速インストーラを使ってみてください。<a href="http://ja.wikipedia.org/wiki/CURL">curl</a> ライブラリを使用し、oil の必要最小限のバージョンをインストールできます。それから、Fuel の新しい完全なアプリケーションを作成できます。</p>
 
 			<pre class="cli"><code># oil を Web からクイックインストールします
-$ curl get.fuelphp.com/oil | sh
+$ curl https://get.fuelphp.com/oil | sh
 # oil が、たった今、インストールされました。Sites ディレクトリで blog プロジェクトを作ります
 $ cd Sites/
 $ oil create blog</code></pre>


### PR DESCRIPTION
oil のダウンロードURLは本家では`https://get.fuelphp.com/oil `となっており、HTTPでは301エラーで失敗します。